### PR TITLE
fix: circular dependencies

### DIFF
--- a/src/entity-base.ts
+++ b/src/entity-base.ts
@@ -1,0 +1,16 @@
+import { HttpClient } from '@angular/common/http';
+import { RelatedCollectionRef } from './related-collection-ref';
+import { RelatedEntityRef } from './related-entity-ref';
+import { Observable } from 'rxjs';
+
+export abstract class EntityBase {
+  http: HttpClient;
+  _links: any;
+
+  protected constructor() {}
+
+  abstract relatedCollection(name: string): RelatedCollectionRef;
+  abstract relatedEntity(name: string): RelatedEntityRef;
+  abstract save(): Observable<void>;
+  abstract update(object: object): Observable<void>;
+}

--- a/src/entity-helper.ts
+++ b/src/entity-helper.ts
@@ -1,13 +1,12 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Entity } from './entity';
-import { Page } from './page';
+import { EntityBase } from './entity-base';
 
 // @dynamic
 export class EntityHelper {
   static transformForUpdate(object: object): object {
     const result: any = {};
     for (const key in object) {
-      if (object[key] instanceof Entity) {
+      if (object[key] instanceof EntityBase) {
         result[key] = EntityHelper.stripTemplatedUrl(object[key]['_links']['self']['href']);
       } else if (object[key] !== '_links') {
         result[key] = object[key];
@@ -16,7 +15,7 @@ export class EntityHelper {
     return result as object;
   }
 
-  static initEntity<E extends Entity>(type: new () => E, payload: object, http: HttpClient): E {
+  static initEntity<E extends EntityBase>(type: new () => E, payload: object, http: HttpClient): E {
     const entity = new type();
     for (const p in payload) {
       entity[p] = payload[p];
@@ -25,24 +24,10 @@ export class EntityHelper {
     return entity;
   }
 
-  static initEntityCollection<E extends Entity>(type: new () => E, payload: any, http: HttpClient): E[] {
+  static initEntityCollection<E extends EntityBase>(type: new () => E, payload: any, http: HttpClient): E[] {
     return payload._embedded[Object.keys(payload['_embedded'])[0]].map(item =>
       EntityHelper.initEntity(type, item, http)
     );
-  }
-
-  static initPage<E extends Entity>(type: new () => E, payload: any, http: HttpClient): Page<E> {
-    const page = new Page(type, http);
-    page.items = EntityHelper.initEntityCollection(type, payload, http);
-    page.totalItems = payload.page ? payload.page.totalElements : page.items.length;
-    page.totalPages = payload.page ? payload.page.totalPages : 1;
-    page.pageNumber = payload.page ? payload.page.number : 1;
-    page.selfUrl = payload._links.self ? EntityHelper.stripTemplatedUrl(payload._links.self.href) : undefined;
-    page.nextUrl = payload._links.next ? EntityHelper.stripTemplatedUrl(payload._links.next.href) : undefined;
-    page.prevUrl = payload._links.prev ? EntityHelper.stripTemplatedUrl(payload._links.prev.href) : undefined;
-    page.firstUrl = payload._links.first ? EntityHelper.stripTemplatedUrl(payload._links.first.href) : undefined;
-    page.lastUrl = payload._links.last ? EntityHelper.stripTemplatedUrl(payload._links.last.href) : undefined;
-    return page;
   }
 
   static stripTemplatedUrl(url: string): string {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -3,12 +3,11 @@ import { HttpClient } from '@angular/common/http';
 import { EntityHelper } from './entity-helper';
 import { RelatedEntityRef } from './related-entity-ref';
 import { RelatedCollectionRef } from './related-collection-ref';
+import { EntityBase } from './entity-base';
 
-export abstract class Entity {
+export abstract class Entity extends EntityBase {
   http: HttpClient;
   _links: any;
-
-  protected constructor() {}
 
   relatedCollection(name: string): RelatedCollectionRef {
     if (this._links[name]) {

--- a/src/paginated-collection-ref.ts
+++ b/src/paginated-collection-ref.ts
@@ -1,4 +1,3 @@
-import { EntityHelper } from './entity-helper';
 import { Page } from './page';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
@@ -26,7 +25,7 @@ export class PaginatedCollectionRef {
     return this.http
       .get<object>(this.url, { params })
       .pipe(
-        map<object, Page<E>>(data => EntityHelper.initPage(type, data, this.http))
+        map<object, Page<E>>(data => Page.initPage(type, data, this.http))
       );
   }
 }


### PR DESCRIPTION
- Entity -> EntityHelper -> Entity
  - adds new EntityBase abstract class
- EntityHelper -> Page -> EntityHelper
  - moves `initPage` to Page

This is needed to start untangling some of the circular dependencies in the main app.